### PR TITLE
add Kumar et al (2020) citation

### DIFF
--- a/_data/pubs.yml
+++ b/_data/pubs.yml
@@ -1,4 +1,25 @@
-- id: Cai2019 
+- id: Kumar2020
+  title: "BrainIAK tutorials: User-friendly learning materials for advanced fMRI analysis"
+  date: 2020-01-15
+  authors:
+     - Manoj Kumar
+     - Cameron T. Ellis
+     - Qihong Lu
+     - Hejia Zhang
+     - Mihai Capotă
+     - Theodore L. Willke
+     - Peter J. Ramadge
+     - Nicholas B. Turk-Browne
+     - Kenneth A. Norman
+  journal: PLOS Computational Biology
+  volume: 16
+  number: 1
+  year: 2020
+  pages: e1007549
+  links:
+     paper: "https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1007549"
+
+- id: Cai2019
   title: "Representational structure or task structure? Bias in neural representational similarity analysis and a Bayesian method for reducing bias"
   date: 2019-05-24
   authors:
@@ -15,7 +36,7 @@
      paper: "https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1006299"
      docs: "https://brainiak.org/docs/brainiak.reprsimil.html"
 
-- id: baldassano2018-1 
+- id: baldassano2018-1
   title: "Representation of real-world event schemas during narrative perception"
   date: 2018-09-24
   authors:
@@ -97,7 +118,7 @@
      code: "https://github.com/brainiak/brainiak/tree/master/brainiak/fcma"
      docs: "http://brainiak.org/docs/brainiak.fcma.html"
 
-- id: baldassano2017-1 
+- id: baldassano2017-1
   title: "Discovering Event Structure in Continuous Narrative Perception and Memory"
   date: 2017-08-02
   authors:

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -419,6 +419,7 @@ We have compiled a list of useful resources that cover the basics of GitHUB, Pyt
 
 Like BrainIAK itself, these tutorials are open-sourced as a service to the field and can be freely used, modified, and shared. They are licensed under the Apache License, Version 2.0. If you find them helpful in your research or re-use code they contain, you might consider citing:
 
-Kumar, M., Ellis, C. T., Lu, Q., Zhang, H., Capota, M., Willke, T. L., Ramadge, P. J., Turk-Browne, N.B., Norman, K. (2019). BrainIAK tutorials: user-friendly learning materials for advanced fMRI analysis. Retrieved from [https://osf.io/j4sbc](https://osf.io/j4sbc).
+Kumar, M., Ellis, C.T., Lu, Q., Zhang, H., Capotă, M., Willke, T.L., Ramadge, P.J., Turk-Browne, N.B. and Norman, K.A., 2020. BrainIAK tutorials: User-friendly learning materials for advanced fMRI analysis. PLoS Computational Biology, 16(1), e1007549. [https://doi.org/10.1371/journal.pcbi.1007549](https://doi.org/10.1371/journal.pcbi.1007549)
+
 </div>
 </div>


### PR DESCRIPTION
I added the citation to the bottom of the tutorials index page and also to the _data/pubs.yml file.

The thing I don't understand though is how _data/pubs.yml builds _site/pubs/index.html. I wasn't able to get this to build on my system, so I haven't been able to test that that change is correctly implemented.